### PR TITLE
Add meaningful error messages for GORM errors

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,16 +17,16 @@ services:
 
 
 
-  server:
-    build:
-      context: .
-      dockerfile: server/Dockerfile
-    container_name: dictionary_server
-    depends_on:
-      - postgres
-    ports:
-      - "8080:8080"
-    working_dir: /app
-    command: ["go", "run", "server/server.go"]
+  # server:
+  #   build:
+  #     context: .
+  #     dockerfile: server/Dockerfile
+  #   container_name: dictionary_server
+  #   depends_on:
+  #     - postgres
+  #   ports:
+  #     - "8080:8080"
+  #   working_dir: /app
+  #   command: ["go", "run", "server/server.go"]
 
 

--- a/server/database/database.go
+++ b/server/database/database.go
@@ -1,11 +1,14 @@
 package database
 
 import (
+	"errors"
+	"fmt"
 	"log"
 	"os"
 
 	"github.com/joho/godotenv"
 	dbmodels "github.com/staszkiet/DictionaryGolang/server/database/models"
+	customerrors "github.com/staszkiet/DictionaryGolang/server/errors"
 	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
 )
@@ -32,4 +35,40 @@ func ConnectDB() *gorm.DB {
 
 	return db
 
+}
+
+type ErrorOptions struct {
+	Polish   string
+	English  string
+	Sentence string
+}
+
+func CheckWhichDoesntExits(eo ErrorOptions, tx *gorm.DB) error {
+	var word dbmodels.Word
+	var translation dbmodels.Translation
+	var sentence dbmodels.Sentence
+	err := tx.Model(&dbmodels.Word{}).Where("polish = ?", eo.Polish).First(&word).Error
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return customerrors.WordNotExistsError{Word: eo.Polish}
+		}
+		return err
+	}
+	err = tx.Model(&dbmodels.Translation{}).Where("english = ? AND word_id = ?", eo.English, word.ID).First(&translation).Error
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return customerrors.TranslationNotExistsError{Word: eo.Polish, Translation: eo.English}
+		}
+		return err
+	}
+	if eo.Sentence != "" {
+		err = tx.Model(&dbmodels.Sentence{}).Where("sentence = ? AND translation_id = ?", eo.Sentence, translation.ID).First(&sentence).Error
+		if err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				return customerrors.SentenceNotExistsError{Word: eo.Polish, Translation: eo.English, Sentence: eo.Sentence}
+			}
+			return err
+		}
+	}
+	return fmt.Errorf("nieznany błąd")
 }

--- a/server/errors/errors.go
+++ b/server/errors/errors.go
@@ -6,6 +6,52 @@ type WordExistsError struct {
 	Word string
 }
 
-func (e *WordExistsError) Error() string {
-	return fmt.Sprintf("word '%s' already exists in the database", e.Word)
+func (e WordExistsError) Error() string {
+	return fmt.Sprintf("słowo %s znajduje się już w słowniku. Aby dodać tłumaczenie użyj polecenia ADD_TRANSLATION", e.Word)
+}
+
+type SentenceExistsError struct {
+	Word        string
+	Translation string
+	Sentence    string
+}
+
+func (e SentenceExistsError) Error() string {
+	return fmt.Sprintf("zdanie %s już jest dodane do tłumaczenia %s słowa %s", e.Sentence, e.Translation, e.Word)
+}
+
+type TranslationExistsError struct {
+	Word        string
+	Translation string
+}
+
+func (e TranslationExistsError) Error() string {
+	return fmt.Sprintf("tłumaczenie %s już jest dodane do słowa %s", e.Translation, e.Word)
+}
+
+type WordNotExistsError struct {
+	Word string
+}
+
+func (e WordNotExistsError) Error() string {
+	return fmt.Sprintf("słowa %s nie ma w słowniku", e.Word)
+}
+
+type SentenceNotExistsError struct {
+	Word        string
+	Translation string
+	Sentence    string
+}
+
+func (e SentenceNotExistsError) Error() string {
+	return fmt.Sprintf("zdanie %s prezentujące tłumaczenie %s słowa %s nie istnieje w słowniku", e.Sentence, e.Translation, e.Word)
+}
+
+type TranslationNotExistsError struct {
+	Word        string
+	Translation string
+}
+
+func (e TranslationNotExistsError) Error() string {
+	return fmt.Sprintf("tłumaczenie %s słowa %s nie istnieje w słowniku", e.Translation, e.Word)
 }


### PR DESCRIPTION
Add messages in polish for errors when word doesn't exist in database and when user tries to modify words without respec for uniqueIndex constraints